### PR TITLE
feat(rules): add roman numerals prevalidate rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/brandenc40/romannumeral v1.1.5
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/brandenc40/romannumeral v1.1.5 h1:X9vvg5iJATxGzs0u4p1StxlFixPdDcHT44eBv4T5kRk=
+github.com/brandenc40/romannumeral v1.1.5/go.mod h1:BGaddAnc6x74z0muZeTu0Z+OMhQXfd8U76vkSLIPvxk=
 github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=
 github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -9,4 +9,5 @@ const (
 	GuessNormallyRuleId = 1 << iota
 	NoValidateRuleId    = 1 << iota
 	FibonacciRuleId     = 1 << iota
+	RomanNumeralRuleId  = 1 << iota
 )

--- a/internal/rules/roman_numerals.go
+++ b/internal/rules/roman_numerals.go
@@ -1,0 +1,58 @@
+package rules
+
+import (
+	"strings"
+
+	rom "github.com/brandenc40/romannumeral"
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/countula/internal/database"
+	"gorm.io/gorm"
+)
+
+type RomanNumeralRule struct {
+	id       int
+	weight   int
+	ruleType string
+}
+
+func (rnr RomanNumeralRule) Id() int {
+	return rnr.id
+}
+func (rnr RomanNumeralRule) Name() string {
+	return "Roman Numeral"
+}
+func (rnr RomanNumeralRule) Description() string {
+	return "You **must** guess in Roman Numerals."
+}
+func (rnr RomanNumeralRule) Weight() int {
+	return rnr.weight
+}
+func (rnr RomanNumeralRule) Type() string {
+	return rnr.ruleType
+}
+func (rnr RomanNumeralRule) OnNewGame(_ *gorm.DB, _ *discordgo.Session, _ database.Turn, _ string) {}
+
+func (rnr RomanNumeralRule) PreValidate(db *gorm.DB, dg *discordgo.Session, msg discordgo.Message) (int, error) {
+	digits := strings.Split(msg.Content, " ")[0]
+	guess, err := rom.StringToInt(digits)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return guess, nil
+}
+
+var (
+	RomanNumeral = (func() Rule {
+		rnr := RomanNumeralRule{
+			id:       RomanNumeralRuleId,
+			weight:   15,
+			ruleType: PreValidateType,
+		}
+
+		registerRule(rnr)
+
+		return rnr
+	})()
+)


### PR DESCRIPTION
This PR adds a new pre-validate rule which requires answers to be given as roman numerals

![image](https://github.com/Zaptross/countula/assets/26305909/c88e59c6-eff8-4ebd-af87-961440373db0)
