### PR TITLE
feat(rules): add jeopardy prevalidate rule

### DIFF
--- a/internal/rules/jeopardy.go
+++ b/internal/rules/jeopardy.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/countula/internal/database"
+	"gorm.io/gorm"
+)
+
+type JeopardyRule struct {
+	id       int
+	weight   int
+	ruleType string
+}
+
+func (jr JeopardyRule) Id() int {
+	return jr.id
+}
+func (jr JeopardyRule) Name() string {
+	return "Jeopardy"
+}
+func (jr JeopardyRule) Description() string {
+	return "You **must** guess in the form: `What is X + Y?`, where X and Y are numbers that add up to the next number."
+}
+func (jr JeopardyRule) Weight() int {
+	return jr.weight
+}
+func (jr JeopardyRule) Type() string {
+	return jr.ruleType
+}
+func (jr JeopardyRule) OnNewGame(_ *gorm.DB, _ *discordgo.Session, _ database.Turn, _ string) {}
+
+var (
+	jeopardyRegex = regexp.MustCompile(`[Ww]hat is (\d+) (?:\+|plus) (\d+)\??`)
+)
+
+func (jr JeopardyRule) PreValidate(db *gorm.DB, dg *discordgo.Session, msg discordgo.Message) (int, error) {
+	matches := jeopardyRegex.FindStringSubmatch(msg.Content)
+
+	if len(matches) == 0 {
+		return 0, errors.New("no matches found")
+	}
+
+	guess := 0
+	for _, match := range matches[1:] {
+		num, err := strconv.Atoi(match)
+		if err != nil {
+			return 0, err
+		}
+		guess += num
+	}
+
+	return guess, nil
+}
+
+var (
+	Jeopardy = (func() Rule {
+		jr := JeopardyRule{
+			id:       JeopardyRuleId,
+			weight:   10,
+			ruleType: PreValidateType,
+		}
+
+		registerRule(jr)
+
+		return jr
+	})()
+)

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -10,4 +10,5 @@ const (
 	NoValidateRuleId    = 1 << iota
 	FibonacciRuleId     = 1 << iota
 	RomanNumeralRuleId  = 1 << iota
+	JeopardyRuleId      = 1 << iota
 )


### PR DESCRIPTION
This PR adds a new rule which requires players to make their guesses in the form:
`What is X plus Y?`
Where `X` and `Y` are both numbers which sum to the next number in the sequence.

![image](https://github.com/Zaptross/countula/assets/26305909/4f2b5f8c-8281-4b5b-9c2d-ce8b0edbf545)
