### PR TITLE
Feat/25 rule count of the hill

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -23,7 +24,7 @@ func main() {
 	envconfig.Process("database", &dbConfig)
 
 	db := database.Connect(dbConfig)
-	log.Default().Println("Connected to database")
+	slog.Info("Connected to database")
 
 	var botConfig DiscordConfig
 	envconfig.Process("discord", &botConfig)
@@ -32,10 +33,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	log.Default().Println("Connected to Discord")
+	slog.Info("Connected to Discord")
 
 	dg.AddHandler(handler.GetMessageHandler(db))
-	log.Default().Println("Added message handler")
+	slog.Info("Added message handler")
 
 	dg.AddHandler(handler.GetOnInteractionHandler(db))
 	_, err = dg.ApplicationCommandCreate(botConfig.AppID, "", handler.GetSlashCommand())
@@ -44,7 +45,7 @@ func main() {
 		log.Fatal(err)
 		panic(err)
 	}
-	log.Default().Println("Added slash commands handler")
+	slog.Info("Added slash commands handler")
 
 	err = dg.Open()
 	if err != nil {
@@ -63,7 +64,7 @@ func main() {
 			dg.ChannelMessageSend(sc.CountingChannelID, t)
 		}
 
-		log.Default().Println("Sent awaken messages")
+		slog.Info("Sent awaken messages")
 	}
 
 	sc := make(chan os.Signal, 1)

--- a/internal/emoji/emoji.go
+++ b/internal/emoji/emoji.go
@@ -7,4 +7,5 @@ const (
 	SHEEP      = "🐑"
 	BALLOON    = "🎈"
 	BOOM       = "💥"
+	FIST       = "✊"
 )

--- a/internal/game/rules.go
+++ b/internal/game/rules.go
@@ -3,6 +3,7 @@ package game
 import (
 	"github.com/zaptross/countula/internal/database"
 	"github.com/zaptross/countula/internal/rules"
+	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
 )
 
@@ -16,5 +17,12 @@ func getRulesForNewGame(db *gorm.DB, guildID string) int {
 	c := rules.GetRandomCountRule(allRules)
 	v := rules.GetRandomValidateRule(allRules)
 
-	return pv.Id() | c.Id() | v.Id()
+	proposedRules := pv.Id() | c.Id() | v.Id()
+	finalRules := rules.OverrideRuleSelections(proposedRules)
+
+	if proposedRules != finalRules {
+		slog.Info("Rules for new game altered by rule overrides", "proposed_rules", proposedRules, "final_rules", finalRules)
+	}
+
+	return finalRules
 }

--- a/internal/handler/guess.go
+++ b/internal/handler/guess.go
@@ -1,8 +1,7 @@
 package handler
 
 import (
-	"fmt"
-	"time"
+	"log/slog"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/zaptross/countula/internal/database"
@@ -31,7 +30,7 @@ func handleGuess(db *gorm.DB, s *discordgo.Session, m *discordgo.MessageCreate, 
 
 	for _, vr := range currentTurnRules.ValidateRules {
 		if !vr.Validate(db, turn, *m.Message, guess) {
-			println(fmt.Sprintf("%s - Failed validation at rule: %s, with guess: %d, after last guess: %d", time.Now().Format(time.RFC3339), vr.Name(), guess, turn.Guess))
+			slog.Info("Incorrect guess", "rule", vr.Name(), "guess", guess, "last_guess", turn.Guess)
 			failValidate(
 				vr.OnFailure(&rules.FailureContext{
 					DB:             db,

--- a/internal/rules/count_of_the_hill.go
+++ b/internal/rules/count_of_the_hill.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/samber/lo"
+	"github.com/zaptross/countula/internal/database"
+	"github.com/zaptross/countula/internal/emoji"
+	"gorm.io/gorm"
+)
+
+type CountOfTheHillRule struct {
+	RuleWeight
+	id       int
+	ruleType string
+}
+
+func (cothr CountOfTheHillRule) Id() int {
+	return cothr.id
+}
+func (cothr CountOfTheHillRule) Name() string {
+	return "Count of the Hill"
+}
+func (cothr CountOfTheHillRule) Description() string {
+	return "To become Count of the Hill, you must guess correctly after the previous player by counting up in 2's.\nWhile you are Count of the Hill, you must guess correctly after yourself by counting up in 4's."
+}
+func (cothr CountOfTheHillRule) Weight() int {
+	return cothr.Current
+}
+func (cothr CountOfTheHillRule) WithWeight(weight int) Rule {
+	return CountOfTheHillRule{
+		id:         cothr.id,
+		ruleType:   cothr.ruleType,
+		RuleWeight: SetupWeight(weight),
+	}
+}
+func (cothr CountOfTheHillRule) Type() string {
+	return cothr.ruleType
+}
+func (cothr CountOfTheHillRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database.Turn, channelID string) {
+}
+func (cothr CountOfTheHillRule) OnFailure(fc *FailureContext) *FailureContext {
+	var gameTurns []database.Turn
+	fc.DB.Find(&gameTurns, "game = ?", fc.LastTurn.Game)
+
+	hillTurns := lo.Reduce(gameTurns, func(acc map[string]int, t database.Turn, i int) map[string]int {
+		// If the current turn is correct and the previous turn was by the same user
+		// then increment the count for that user.
+		if i > 0 && t.Correct && gameTurns[i-1].UserID == t.UserID {
+			acc[t.UserID]++
+		}
+		return acc
+	}, map[string]int{})
+
+	hillUser := ""
+	hillPoints := 0
+
+	for user, points := range hillTurns {
+		if points > hillPoints {
+			hillUser = user
+			hillPoints = points
+		}
+	}
+
+	if hillUser != "" {
+		go fc.DG.ChannelMessageSend(fc.LastTurn.ChannelID, fmt.Sprintf("The Count of the Hill was <@%s> with %d hill points %s", hillUser, hillPoints, emoji.FIST))
+	}
+
+	return fc
+}
+
+func (cothr CountOfTheHillRule) Validate(db *gorm.DB, lastTurn database.Turn, msg discordgo.Message, guess int) bool {
+	if lastTurn.UserID == msg.Author.ID {
+		return guess == lastTurn.Guess+4
+	}
+	return guess == lastTurn.Guess+2
+}
+
+var (
+	CountOfTheHill = (func() ValidateRule {
+		cothr := CountOfTheHillRule{
+			id:         CountOfTheHillRuleId,
+			RuleWeight: SetupWeight(CountOfTheHillRuleWeight),
+			ruleType:   CountType,
+		}
+
+		registerRule(cothr)
+
+		return cothr
+	})()
+)

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -4,18 +4,19 @@ import "github.com/zaptross/countula/internal/emoji"
 
 const (
 	// Order matters here
-	IncrementRule1Id    = 1 << iota
-	IncrementRule2Id    = 1 << iota
-	IncrementRule3Id    = 1 << iota
-	IncrementRule7Id    = 1 << iota
-	TakeTurnsRuleId     = 1 << iota
-	GuessNormallyRuleId = 1 << iota
-	NoValidateRuleId    = 1 << iota
-	FibonacciRuleId     = 1 << iota
-	RomanNumeralRuleId  = 1 << iota
-	JeopardyRuleId      = 1 << iota
-	GoodyTwoShoesRuleId = 1 << iota
-	KeepyUppiesRuleId   = 1 << iota
+	IncrementRule1Id     = 1 << iota
+	IncrementRule2Id     = 1 << iota
+	IncrementRule3Id     = 1 << iota
+	IncrementRule7Id     = 1 << iota
+	TakeTurnsRuleId      = 1 << iota
+	GuessNormallyRuleId  = 1 << iota
+	NoValidateRuleId     = 1 << iota
+	FibonacciRuleId      = 1 << iota
+	RomanNumeralRuleId   = 1 << iota
+	JeopardyRuleId       = 1 << iota
+	GoodyTwoShoesRuleId  = 1 << iota
+	KeepyUppiesRuleId    = 1 << iota
+	CountOfTheHillRuleId = 1 << iota
 )
 
 // Default Rule Weights
@@ -26,12 +27,13 @@ const (
 	JeopardyRuleWeight      = 16
 
 	// Count Rules
-	IncrementRule1Weight    = 18
-	IncrementRule2Weight    = 22
-	IncrementRule3Weight    = 22
-	IncrementRule7Weight    = 14
-	FibonacciRuleWeight     = 14
-	GoodyTwoShoesRuleWeight = 10
+	IncrementRule1Weight     = 16
+	IncrementRule2Weight     = 20
+	IncrementRule3Weight     = 20
+	IncrementRule7Weight     = 12
+	FibonacciRuleWeight      = 12
+	GoodyTwoShoesRuleWeight  = 10
+	CountOfTheHillRuleWeight = 10
 
 	// Validate Rules
 	NoValidateRuleWeight  = 35
@@ -45,4 +47,14 @@ func OverrideSuccessEmoji(ruleId int) string {
 		return emoji.BALLOON
 	}
 	return emoji.CHECK
+}
+
+func OverrideRuleSelections(rules int) int {
+	switch true {
+	case rules&(TakeTurnsRuleId|CountOfTheHillRuleId) == TakeTurnsRuleId|CountOfTheHillRuleId:
+		// Replace Take Turns with NoValidate while Count of the Hill is active,
+		// because Count of the Hill has custom behavior for taking turns.
+		return rules ^ (TakeTurnsRuleId | NoValidateRuleId)
+	}
+	return rules
 }

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -36,9 +36,9 @@ const (
 	CountOfTheHillRuleWeight = 10
 
 	// Validate Rules
-	NoValidateRuleWeight  = 35
+	NoValidateRuleWeight  = 30
 	TakeTurnsRuleWeight   = 55
-	KeepyUppiesRuleWeight = 10
+	KeepyUppiesRuleWeight = 15
 )
 
 func OverrideSuccessEmoji(ruleId int) string {


### PR DESCRIPTION
Fixes #25 

This PR adds the `Count of the Hill` Rule!

This rule incentivises streaking back to back answers together, and has a special callout for the player who stays atop the hill longest.

**Note**: Count of the Hill is incompatible with Take Turns, and as such Take Turns will be replaced with No Validation for that game whenever they clash.

### Simple Scenario

![image](https://github.com/user-attachments/assets/0fdc2c44-eaeb-4d9c-85b0-703419934b52)


### Complex Scenario

![image](https://github.com/user-attachments/assets/184c4021-d9e0-4006-b727-4d963bf587dd)
