### PR TITLE
Feat/jeopardy and maths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
     database:
         image: "postgres:latest"
-        # ports:
-        #     - "${DATABASE_PORT}:5432"
+        ports:
+            - "${DATABASE_PORT}:5432"
         environment:
             - "POSTGRES_USER=${DATABASE_USER}"
             - "POSTGRES_PASSWORD=${DATABASE_PASSWORD}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,24 @@
-version: "3.9"
 services:
     database:
         image: "postgres:latest"
-        ports:
-            - "${DATABASE_PORT}:5432"
+        # ports:
+        #     - "${DATABASE_PORT}:5432"
         environment:
-            - "DATABASE_USER=${DATABASE_USER}"
-            - "DATABASE_PASSWORD=${DATABASE_PASSWORD}"
-            - "DATABASE_DB=${DATABASE_DB}"
+            - "POSTGRES_USER=${DATABASE_USER}"
+            - "POSTGRES_PASSWORD=${DATABASE_PASSWORD}"
+            - "POSTGRES_DB=${DATABASE_DATABASE}"
         restart: unless-stopped
     countula:
         image: zaptross/countula:latest
-        links:
-            - "database:compose-database"
         depends_on:
             - database
         environment:
             - "DISCORD_TOKEN=${DISCORD_TOKEN}"
+            - "DISCORD_APPID=${DISCORD_APPID}"
             - "DATABASE_USER=${DATABASE_USER}"
             - "DATABASE_PASSWORD=${DATABASE_PASSWORD}"
-            - "DATABASE_DB=${DATABASE_DB}"
+            - "DATABASE_DATABASE=${DATABASE_DATABASE}"
             - "DATABASE_PORT=${DATABASE_PORT}"
-            - "DATABASE_HOST=compose-postgres"
+            - "DATABASE_HOST=database"
             - "DATABASE_SSL=${DATABASE_SSL}"
             - "DATABASE_TIMEZONE=${DATABASE_TIMEZONE}"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/Pramod-Devireddy/go-exprtk v1.1.0
 	github.com/brandenc40/romannumeral v1.1.5
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Pramod-Devireddy/go-exprtk v1.1.0 h1:U/uvXm5UMQ25p6PCnThz51WsxDqAeoynzdnhpQEAxZo=
+github.com/Pramod-Devireddy/go-exprtk v1.1.0/go.mod h1:GbqdmGxU1ESDj3lu8mPbffejPB5UoOtm6eB7qr3YZ94=
 github.com/brandenc40/romannumeral v1.1.5 h1:X9vvg5iJATxGzs0u4p1StxlFixPdDcHT44eBv4T5kRk=
 github.com/brandenc40/romannumeral v1.1.5/go.mod h1:BGaddAnc6x74z0muZeTu0Z+OMhQXfd8U76vkSLIPvxk=
 github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=

--- a/internal/rules/fibonacci.go
+++ b/internal/rules/fibonacci.go
@@ -46,6 +46,12 @@ func (fr FibonacciRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database
 		Correct:   true,
 	}
 
+	correctEmoji := emoji.CHECK
+
+	if fibonacciTurn.Rules&KeepyUppiesRuleId == KeepyUppiesRuleId {
+		correctEmoji = emoji.BALLOON
+	}
+
 	zeroMessage := "0"
 	if fibonacciTurn.Rules&RomanNumeralRuleId == RomanNumeralRuleId {
 		zeroMessage = "nulla"
@@ -55,7 +61,7 @@ func (fr FibonacciRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database
 	if err != nil {
 		panic("Could not create new game: " + err.Error())
 	}
-	go s.MessageReactionAdd(channelID, msg.ID, emoji.CHECK)
+	go s.MessageReactionAdd(channelID, msg.ID, correctEmoji)
 
 	oneMessage := "1"
 	if fibonacciTurn.Rules&RomanNumeralRuleId == RomanNumeralRuleId {
@@ -66,7 +72,7 @@ func (fr FibonacciRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database
 	if err != nil {
 		panic("Could not create new game: " + err.Error())
 	}
-	go s.MessageReactionAdd(channelID, msg.ID, emoji.CHECK)
+	go s.MessageReactionAdd(channelID, msg.ID, correctEmoji)
 
 	fibonacciTurn.MessageID = msg.ID
 	db.Create(&fibonacciTurn)

--- a/internal/rules/maths.go
+++ b/internal/rules/maths.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/Pramod-Devireddy/go-exprtk"
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/countula/internal/database"
+	"gorm.io/gorm"
+)
+
+type MathsRule struct {
+	RuleWeight
+	id       int
+	ruleType string
+}
+
+var (
+	mathsRegex = regexp.MustCompile(`^(?:[ ]|[0-9]+|[(,)+\-*/%^]|sin|cos|tan|acos|asin|atan|atan2|cosh|cot|csc|sec|sinh|tanh|d2r|r2d|d2g|g2d|hyp|min|max|avg|sum|abs|ceil|floor|round|roundn|exp|log|log10|logn|pow|root|sqrt|clamp)+$`)
+)
+
+func (mr MathsRule) Id() int {
+	return mr.id
+}
+func (mr MathsRule) Name() string {
+	return "Maths"
+}
+func (mr MathsRule) Description() string {
+	return "You **must** guess in the form of a mathematical equation, which equals the next number after ignoring all decimal places. For example: `1.1111 * 9` which equals `9.9999` would be treated as `9`."
+}
+func (mr MathsRule) Weight() int {
+	return mr.Current
+}
+func (mr MathsRule) WithWeight(weight int) Rule {
+	return MathsRule{
+		id:         mr.id,
+		ruleType:   mr.ruleType,
+		RuleWeight: SetupWeight(weight),
+	}
+}
+func (mr MathsRule) Type() string {
+	return mr.ruleType
+}
+func (mr MathsRule) OnNewGame(_ *gorm.DB, _ *discordgo.Session, _ database.Turn, _ string) {}
+func (mr MathsRule) OnFailure(fc *FailureContext) *FailureContext {
+	return fc
+}
+
+func (mr MathsRule) PreValidate(db *gorm.DB, dg *discordgo.Session, msg discordgo.Message) (int, error) {
+	if !mathsRegex.MatchString(msg.Content) {
+		// record attempts that don't match the regex
+		go db.Create(&database.AuditLog{
+			ChannelID: msg.ChannelID,
+			MessageID: msg.ID,
+			UserID:    msg.Author.ID,
+			Username:  msg.Author.Username,
+			Action:    "MathsRulePreValidate",
+			Data:      msg.Content,
+		})
+		go dg.ChannelMessageSendReply(msg.ChannelID, "I appreciate the attempt, but that doesn't look like a valid mathematical expression to me.", msg.Reference())
+		return 0, errors.New("forbidden mathematical expression")
+	}
+
+	expr := exprtk.NewExprtk()
+	expr.SetExpression(msg.Content)
+
+	err := expr.CompileExpression()
+	if err != nil {
+		return 0, err
+	}
+
+	result := expr.GetEvaluatedValue()
+
+	return int(result), nil
+}
+
+var (
+	Maths = (func() Rule {
+		mr := MathsRule{
+			id:         MathsRuleId,
+			RuleWeight: SetupWeight(MathsRuleWeight),
+			ruleType:   PreValidateType,
+		}
+
+		registerRule(mr)
+
+		return mr
+	})()
+)

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -17,14 +17,17 @@ const (
 	GoodyTwoShoesRuleId  = 1 << iota
 	KeepyUppiesRuleId    = 1 << iota
 	CountOfTheHillRuleId = 1 << iota
+	MathsRuleId          = 1 << iota
+	// Add new rules above this line only
 )
 
 // Default Rule Weights
 const (
 	// Pre-Validate Rules
-	GuessNormallyRuleWeight = 56
+	GuessNormallyRuleWeight = 54
 	RomanNumeralRuleWeight  = 28
-	JeopardyRuleWeight      = 16
+	JeopardyRuleWeight      = 14
+	MathsRuleWeight         = 4
 
 	// Count Rules
 	IncrementRule1Weight     = 16


### PR DESCRIPTION
This PR adds a new rule, and tweaks an older one:
* jeopardy now does simple maths (no more than 3 operators)
* maths rule does complex and undocumented math
  * maths _probably_ doesn't just crash the server, but we shall see
  
A fix was included: 
* fix: interaction between fibonacci and keepy uppies left two messages with :heavy_check_mark: rather than :balloon: 
![image](https://github.com/user-attachments/assets/a8e7ccec-cabe-4ffe-8543-06b93d9c324f)

This should be resolved