### PR TITLE
Feat/three shoes and doubling season

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,12 @@
 FROM golang:alpine AS build
 
+RUN apk add build-base
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /build
 COPY . .
 RUN go mod download
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN cd /build/cmd/bot && go build -a -o /build/countula
 
 ARG version

--- a/internal/rules/doubling_season.go
+++ b/internal/rules/doubling_season.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/countula/internal/database"
+	"github.com/zaptross/countula/internal/emoji"
+	"gorm.io/gorm"
+)
+
+type DoublingSeasonRule struct {
+	RuleWeight
+	id       int
+	ruleType string
+}
+
+func (dsr DoublingSeasonRule) Id() int {
+	return dsr.id
+}
+func (dsr DoublingSeasonRule) Name() string {
+	return "Doubling Season"
+}
+func (dsr DoublingSeasonRule) Description() string {
+	return "First there was one, then there was two, how many doubles can you do?"
+}
+func (dsr DoublingSeasonRule) Weight() int {
+	return dsr.Current
+}
+func (dsr DoublingSeasonRule) WithWeight(weight int) Rule {
+	return DoublingSeasonRule{
+		id:         dsr.id,
+		ruleType:   dsr.ruleType,
+		RuleWeight: SetupWeight(weight),
+	}
+}
+func (dsr DoublingSeasonRule) Type() string {
+	return dsr.ruleType
+}
+func (dsr DoublingSeasonRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database.Turn, channelID string) {
+	doublingSeasonTurn := database.Turn{
+		ChannelID: channelID,
+		UserID:    ng.UserID,
+		Game:      ng.Game,
+		Rules:     ng.Rules,
+		Turn:      ng.Turn + 1,
+		Guess:     rand.Int() % 6, // pick a random starting number between 1 and 5 for variety
+		Correct:   true,
+	}
+
+	correctEmoji := emoji.CHECK
+
+	if ng.Rules&KeepyUppiesRuleId == KeepyUppiesRuleId {
+		correctEmoji = emoji.BALLOON
+	}
+
+	msg, err := s.ChannelMessageSend(channelID, fmt.Sprintf("Let's start with say...\n\n%d", doublingSeasonTurn.Guess))
+	if err != nil {
+		panic("Could not create new game: " + err.Error())
+	}
+	go s.MessageReactionAdd(channelID, msg.ID, correctEmoji)
+
+	doublingSeasonTurn.MessageID = msg.ID
+	db.Create(&doublingSeasonTurn)
+}
+func (dsr DoublingSeasonRule) OnFailure(fc *FailureContext) *FailureContext { return fc }
+
+func (dsr DoublingSeasonRule) Validate(db *gorm.DB, lastTurn database.Turn, msg discordgo.Message, guess int) bool {
+	return guess == lastTurn.Guess*2
+}
+
+var (
+	DoublingSeason = (func() ValidateRule {
+		dsr := DoublingSeasonRule{
+			id:         DoublingSeasonRuleId,
+			RuleWeight: SetupWeight(DoublingSeasonRuleWeight),
+			ruleType:   CountType,
+		}
+
+		registerRule(dsr)
+
+		return dsr
+	})()
+)

--- a/internal/rules/goodythreeshoes.go
+++ b/internal/rules/goodythreeshoes.go
@@ -1,0 +1,62 @@
+package rules
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/countula/internal/database"
+	"gorm.io/gorm"
+)
+
+type GoodyThreeShoesRule struct {
+	RuleWeight
+	id       int
+	ruleType string
+}
+
+func (gtsr GoodyThreeShoesRule) Id() int {
+	return gtsr.id
+}
+func (gtsr GoodyThreeShoesRule) Name() string {
+	return "Goody... Three Shoes?"
+}
+func (gtsr GoodyThreeShoesRule) Description() string {
+	return "Take three steps forward, then one step back, then one step back."
+}
+func (gtsr GoodyThreeShoesRule) Weight() int {
+	return gtsr.Current
+}
+func (gtsr GoodyThreeShoesRule) WithWeight(weight int) Rule {
+	return GoodyThreeShoesRule{
+		id:         gtsr.id,
+		ruleType:   gtsr.ruleType,
+		RuleWeight: SetupWeight(weight),
+	}
+}
+func (gtsr GoodyThreeShoesRule) Type() string {
+	return gtsr.ruleType
+}
+func (gtsr GoodyThreeShoesRule) OnNewGame(db *gorm.DB, s *discordgo.Session, ng database.Turn, channelID string) {
+}
+func (gtsr GoodyThreeShoesRule) OnFailure(fc *FailureContext) *FailureContext {
+	return fc
+}
+
+func (gtsr GoodyThreeShoesRule) Validate(db *gorm.DB, lastTurn database.Turn, msg discordgo.Message, guess int) bool {
+	if lastTurn.Turn%3 > 0 {
+		return guess == lastTurn.Guess-1
+	}
+	return guess == lastTurn.Guess+3
+}
+
+var (
+	GoodyThreeShoes = (func() ValidateRule {
+		gtsr := GoodyThreeShoesRule{
+			id:         GoodyThreeShoesRuleId,
+			RuleWeight: SetupWeight(GoodyThreeShoesRuleWeight),
+			ruleType:   CountType,
+		}
+
+		registerRule(gtsr)
+
+		return gtsr
+	})()
+)

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -28,8 +28,8 @@ const (
 	// Pre-Validate Rules
 	GuessNormallyRuleWeight = 54
 	RomanNumeralRuleWeight  = 28
-	JeopardyRuleWeight      = 14
-	MathsRuleWeight         = 4
+	JeopardyRuleWeight      = 10
+	MathsRuleWeight         = 8
 
 	// Count Rules
 	IncrementRule1Weight      = 16

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -4,20 +4,21 @@ import "github.com/zaptross/countula/internal/emoji"
 
 const (
 	// Order matters here
-	IncrementRule1Id     = 1 << iota
-	IncrementRule2Id     = 1 << iota
-	IncrementRule3Id     = 1 << iota
-	IncrementRule7Id     = 1 << iota
-	TakeTurnsRuleId      = 1 << iota
-	GuessNormallyRuleId  = 1 << iota
-	NoValidateRuleId     = 1 << iota
-	FibonacciRuleId      = 1 << iota
-	RomanNumeralRuleId   = 1 << iota
-	JeopardyRuleId       = 1 << iota
-	GoodyTwoShoesRuleId  = 1 << iota
-	KeepyUppiesRuleId    = 1 << iota
-	CountOfTheHillRuleId = 1 << iota
-	MathsRuleId          = 1 << iota
+	IncrementRule1Id      = 1 << iota
+	IncrementRule2Id      = 1 << iota
+	IncrementRule3Id      = 1 << iota
+	IncrementRule7Id      = 1 << iota
+	TakeTurnsRuleId       = 1 << iota
+	GuessNormallyRuleId   = 1 << iota
+	NoValidateRuleId      = 1 << iota
+	FibonacciRuleId       = 1 << iota
+	RomanNumeralRuleId    = 1 << iota
+	JeopardyRuleId        = 1 << iota
+	GoodyTwoShoesRuleId   = 1 << iota
+	KeepyUppiesRuleId     = 1 << iota
+	CountOfTheHillRuleId  = 1 << iota
+	MathsRuleId           = 1 << iota
+	GoodyThreeShoesRuleId = 1 << iota
 	// Add new rules above this line only
 )
 
@@ -30,13 +31,14 @@ const (
 	MathsRuleWeight         = 4
 
 	// Count Rules
-	IncrementRule1Weight     = 16
-	IncrementRule2Weight     = 20
-	IncrementRule3Weight     = 20
-	IncrementRule7Weight     = 12
-	FibonacciRuleWeight      = 12
-	GoodyTwoShoesRuleWeight  = 10
-	CountOfTheHillRuleWeight = 10
+	IncrementRule1Weight      = 16
+	IncrementRule2Weight      = 20
+	IncrementRule3Weight      = 20
+	IncrementRule7Weight      = 12
+	FibonacciRuleWeight       = 12
+	GoodyTwoShoesRuleWeight   = 7
+	GoodyThreeShoesRuleWeight = 3
+	CountOfTheHillRuleWeight  = 10
 
 	// Validate Rules
 	NoValidateRuleWeight  = 30

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -19,6 +19,7 @@ const (
 	CountOfTheHillRuleId  = 1 << iota
 	MathsRuleId           = 1 << iota
 	GoodyThreeShoesRuleId = 1 << iota
+	DoublingSeasonRuleId  = 1 << iota
 	// Add new rules above this line only
 )
 
@@ -35,10 +36,11 @@ const (
 	IncrementRule2Weight      = 20
 	IncrementRule3Weight      = 20
 	IncrementRule7Weight      = 12
-	FibonacciRuleWeight       = 12
+	FibonacciRuleWeight       = 6
 	GoodyTwoShoesRuleWeight   = 7
 	GoodyThreeShoesRuleWeight = 3
 	CountOfTheHillRuleWeight  = 10
+	DoublingSeasonRuleWeight  = 6
 
 	// Validate Rules
 	NoValidateRuleWeight  = 30


### PR DESCRIPTION
This PR:
* enables CGO and installs gcc for building the image with math (exptrk requires gcc)
* adds new rules:
  * goody three shoes
  * doubling season

Fixes bugs:
* jeopardy incorrectly parsing any guess without operators to 0, eg: `what is 10?` -> `0`
* jeopardy incorrectly counting operators by not counting word operators