### PR TITLE
fix(build): install and copy over cgo deps

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,13 +1,14 @@
 FROM golang:alpine AS build
 
-RUN apk add build-base
+RUN apk --no-cache add build-base
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /build
 COPY . .
 RUN go mod download
 ENV CGO_ENABLED=1
-RUN cd /build/cmd/bot && go build -a -o /build/countula
+RUN cd /build/cmd/bot && go build -ldflags='-s -w' -trimpath -a -o /build/countula
+RUN ldd /build/countula | tr -s [:blank:] '\n' | grep '^/' | xargs -I {} install -D {} /build/{}
 
 ARG version
 RUN echo "$version" > /etc/program-version
@@ -15,7 +16,7 @@ RUN chattr +i /etc/program-version
 
 # Create the output container from the built image.
 FROM scratch
-COPY --from=build /build/countula /countula
+COPY --from=build /build/ /
 COPY --from=build /etc/ssl/certs/ /etc/ssl/certs
 COPY --from=build /etc/program-version /etc/program-version
 


### PR DESCRIPTION
## Core Problem

When executing the compiled go binary inside the built docker container, the container would error saying "could not find $builtFile", eg:
```
exec /countula: no such file or directory
```

Where `/countula` is the compiled binary

## Resolution

Looks like the issue was that dynamically linked dependencies weren't being built into the binary, and need to be copied across.

## Reading
https://blog.2read.net/posts/building-a-minimalist-docker-container-with-alpine-linux-and-golang/
