### PR TITLE
Ci/fix dockerhub push

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Set outputs
         id: get_sha
@@ -57,7 +57,7 @@ jobs:
 
       - name: Dockerhub Login
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -46,6 +46,7 @@ jobs:
           bump_each_commit: true
 
       - name: build container
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
@@ -61,9 +62,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: push
+      - name: Build and push
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: docker push --all-tags zaptross/countula
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg version="${{ steps.get_version.outputs.version }} \(${{ steps.get_sha.outputs.sha_short }}\)" \
+            -t zaptross/countula:${{ steps.get_version.outputs.version }} \
+            -t zaptross/countula:latest \
+            -f ./Dockerfile . \
+            --push
 
       - name: Update repo description
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This PR readds the docker buildx command for pushing, as [it seems that it can only be pushed from the buildx step, not after](https://github.com/docker/buildx/issues/1152).

It also updates some action versions to their latest.